### PR TITLE
Fix datafix:install generator in Rails 4

### DIFF
--- a/lib/generators/datafix/install/install_generator.rb
+++ b/lib/generators/datafix/install/install_generator.rb
@@ -4,7 +4,10 @@ class Datafix
   module Generators
     class InstallGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
-      extend ActiveRecord::Generators::Migration
+
+      if Rails::VERSION::MAJOR <= 3
+        extend ActiveRecord::Generators::Migration
+      end
 
       # Implement the required interface for Rails::Generators::Migration.
 


### PR DESCRIPTION
Apparently there was an API change between rails 3 and 4 that obviated the need
to extend ActiveRecord::Generators::Migration onto
Datafix::Generators::InstallGenerator. The install task fails with:

```
[WARNING] Could not load generator "generators/datafix/install/install_generator". Error: uninitialized constant ActiveRecord::Generators::Migration.
```

This correct this issue, with all specs passing.
